### PR TITLE
Feat: Additional features for Hashicorp Vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Hashicorp Vault keys file
+cluster-keys.json

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Next :
 Once the cluster has been setup, Hashicorp Vault (now referred to as "vault") is not ready for use. It has to be initialized and to be unsealed. *Secrets will be handled in the following steps.*
 To ensure HA on the cluster, the deployment consists of 3 pods, spread on 3 nodes. (the node autoscaling feature is used here). More pods can be created by modifying Terraform's vars. (HPA is not available though). 
 
+### Manual initialization
 **Initialization of the vault**
 
 Shamir's algorithm is used to encrypt the vault. *n* keys (with *n* > 0) are generated, and *m* keys (with 0 < *m* <= *n*) are needed to unseal the vault. This is achieved with the following command (using `kubectl` in the `hashicorp-vault` namespace):
@@ -61,7 +62,11 @@ The vault is still not available. Each pod must be *unsealed* to be operational.
 
 `kubectl exec hashicorp-vault-i -- vault operator unseal $VAULT_UNSEAL_KEY`, with *i* going from 0 to the number of pods.
 
-Now, your vault is fully operational. First authentication is possible with the root token. The vault has to been unsealed everytime a pod is destroyed, or for any other reasons detailed in Hashicorp Vault's documentation. 
+Now, your vault is fully operational. First authentication is possible with the root token. The vault has to been unsealed everytime a pod is destroyed, or for any other reasons detailed in Hashicorp Vault's documentation.
+
+### Automatic configuration
+
+The Vault may be automatically initialized and unsealed. This is done by executing the script `init.sh` in the `vault` folder, with the following command : `./init.sh`. Then follow the instructions and your Vault should be ready to use at the end.
 
 **Initial configuration**
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Next :
 
 ## Hashicorp Vault
 
-Once the cluster has been setup, Hashicorp Vault (now referred to as "vault") is not ready to use. It has to be initialized as well as to be unsealed. *Secrets will be handled in the following steps.*
-To ensure HA on the cluster, the deployment consists of 3 pods, spread on 3 nodes. (the node autoscaling feature is used here). More pods can be created by modifying the Terraform's vars. (HPA is not available though). 
+Once the cluster has been setup, Hashicorp Vault (now referred to as "vault") is not ready for use. It has to be initialized and to be unsealed. *Secrets will be handled in the following steps.*
+To ensure HA on the cluster, the deployment consists of 3 pods, spread on 3 nodes. (the node autoscaling feature is used here). More pods can be created by modifying Terraform's vars. (HPA is not available though). 
 
 **Initialization of the vault**
 
-Shamir's algorithm is used to encrypt the vault. *n* (with *n* > 0) are generated, and *m* keys (with 0 < *m* <= *n*) are needed to unseal the vault. This is achieved with the following command (using `kubectl` in the `hashicorp-vault` namespace):
+Shamir's algorithm is used to encrypt the vault. *n* keys (with *n* > 0) are generated, and *m* keys (with 0 < *m* <= *n*) are needed to unseal the vault. This is achieved with the following command (using `kubectl` in the `hashicorp-vault` namespace):
 
 ```bash
 kubectl exec hashicorp-vault-0 -- vault operator init \
@@ -53,7 +53,7 @@ This command generates a `cluster-keys.json` file containing :
 * the *n* generated keys
 * a root token, used to authenticate to the vault (once unsealed)
 
-*If you read the doc, you might want to make the pods join the Raft cluster. The vault is here automatically set up to join the Raft cluster, so no action is required from the user here.*
+*If you read the doc, you might want to make the pods join the Raft cluster. The vault is here configured to join the Raft cluster by itself, so no action is required from the user here.*
 
 **Unsealing of the vault**
 
@@ -62,3 +62,12 @@ The vault is still not available. Each pod must be *unsealed* to be operational.
 `kubectl exec hashicorp-vault-i -- vault operator unseal $VAULT_UNSEAL_KEY`, with *i* going from 0 to the number of pods.
 
 Now, your vault is fully operational. First authentication is possible with the root token. The vault has to been unsealed everytime a pod is destroyed, or for any other reasons detailed in Hashicorp Vault's documentation. 
+
+**Initial configuration**
+
+This part is not mandatory. It deploys the Key/Value engine on the Vault, as well as a Kubernetes backend for authentication (for instance used by the argocd-vault plugin).
+The k8s backend has read-access on the path `kv/*`.
+
+Go to the `vault` folder, create a `terraform.tfvars` and fill it with the required variables. Then do a `terraform init`, then `terraform plan` then `terraform apply`.
+
+**Congratulations! Your Hashicorp Vault is now ready to use, enjoy!**

--- a/README.md
+++ b/README.md
@@ -33,3 +33,31 @@ Next :
 - Copy the `credentials.auto.tfvars.json.template` to `credentials.auto.tfvars.json` and fill it with the corresponding credentials
 - Do a `terraform init`, then `terraform plan` then `terraform apply` to create your cluster. 
 
+## Hashicorp Vault
+
+Once the cluster has been setup, Hashicorp Vault (now referred to as "vault") is not ready to use. It has to be initialized as well as to be unsealed. *Secrets will be handled in the following steps.*
+To ensure HA on the cluster, the deployment consists of 3 pods, spread on 3 nodes. (the node autoscaling feature is used here). More pods can be created by modifying the Terraform's vars. (HPA is not available though). 
+
+**Initialization of the vault**
+
+Shamir's algorithm is used to encrypt the vault. *n* (with *n* > 0) are generated, and *m* keys (with 0 < *m* <= *n*) are needed to unseal the vault. This is achieved with the following command (using `kubectl` in the `hashicorp-vault` namespace):
+
+```bash
+kubectl exec hashicorp-vault-0 -- vault operator init \
+    -key-shares=n \
+    -key-threshold=m \
+    -format=json > cluster-keys.json
+```
+
+This command generates a `cluster-keys.json` file containing :
+* the *n* generated keys
+* a root token, used to authenticate to the vault (once unsealed)
+
+*If you read the doc, you might want to make the pods join the Raft cluster. The vault is here automatically set up to join the Raft cluster, so no action is required from the user here.*
+
+**Unsealing of the vault**
+The vault is still not available. Each pod must be *unsealed* to be operational. This can be achieved by doing so (still in the `hashicorp-vault` namespace), here with *n* = *m* = 1 :
+
+`kubectl exec hashicorp-vault-i -- vault operator unseal $VAULT_UNSEAL_KEY`, with *i* going from 0 to the number of pods.
+
+Now, your vault is fully operational. First authentication is possible with the root token. The vault has to been unsealed everytime a pod is destroyed, or for any other reasons detailed in Hashicorp Vault's documentation. 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Next :
 Once the cluster has been setup, Hashicorp Vault (now referred to as "vault") is not ready for use. It has to be initialized and to be unsealed. *Secrets will be handled in the following steps.*
 To ensure HA on the cluster, the deployment consists of 3 pods, spread on 3 nodes. (the node autoscaling feature is used here). More pods can be created by modifying Terraform's vars. (HPA is not available though). 
 
+*To perform the following steps, you need to have every pod in the `Running` state. You can check this with `kubectl get pods -n hashicorp-vault`. (they won't be marked as ready however)*
+
 ### Manual initialization
 **Initialization of the vault**
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This command generates a `cluster-keys.json` file containing :
 *If you read the doc, you might want to make the pods join the Raft cluster. The vault is here automatically set up to join the Raft cluster, so no action is required from the user here.*
 
 **Unsealing of the vault**
+
 The vault is still not available. Each pod must be *unsealed* to be operational. This can be achieved by doing so (still in the `hashicorp-vault` namespace), here with *n* = *m* = 1 :
 
 `kubectl exec hashicorp-vault-i -- vault operator unseal $VAULT_UNSEAL_KEY`, with *i* going from 0 to the number of pods.

--- a/common/vault-values.yml
+++ b/common/vault-values.yml
@@ -61,6 +61,15 @@ server:
     hosts:
       - host: ${vault_server_hostname}
   %{ endif }
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: vault
+            app.kubernetes.io/instance: hashicorp-vault
+            component: server
+        topologyKey: kubernetes.io/hostname
   extraVolumes:
       - type: secret
         name: ${kubernetes_secret_name_tls_cert}

--- a/common/vault-values.yml
+++ b/common/vault-values.yml
@@ -63,7 +63,7 @@ server:
   %{ endif }
   affinity: |
     podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
+      preferredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:
           matchLabels:
             app.kubernetes.io/name: vault

--- a/vault/.terraform.lock.hcl
+++ b/vault/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "3.15.0"
+  constraints = "3.15.0"
+  hashes = [
+    "h1:MBA2SqWSuqCj9XXPza4K4Al6oSvYiJcX33fxN+wlALs=",
+    "zh:3464a21c259069ebd24a5aaf45e9f3852de38eb2b0e2f888bb15abad2d683835",
+    "zh:63999934c27d2e1c8e9461c3d63183e17fbc7cd4977fc737a1264da86cb8ee0d",
+    "zh:6aa21738497da9e387ec7eedc0b4c1b3e2e0882f3b96b17ff2e91f066db5be27",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86acc6d68b1a0a37ccbef2912762a79a981c06e5a44f94284aaadaa6c9a2dd05",
+    "zh:903db157400171e0c7bf363f007294dac7d19703a7fa32fbb007d40a300968af",
+    "zh:97d74082a8e1c3e95297038f9bffb87437890799147d1f52a3c60c3a2fe4d338",
+    "zh:b76671fe6fc5e5f9695ed8b144ed97a7bbc3fc9f67cd395aebe6970bb1802f48",
+    "zh:b7ef8a51e3b3e7fe2208956690d0f02262ce46e655a31cd5ef5484cce04d4a11",
+    "zh:c8e65061a57848f84a00bc701d960f42f958c9b46f0063aa19c11af98e94570a",
+    "zh:ec055a10e407c3f5cb1c7a3771ea993380f14ae006a1954d4436b0e1c7dc5c87",
+    "zh:f90e6ed5dfbc8900d70551094cb8796f5b16f9232447929161fee08dcd7a34fb",
+  ]
+}

--- a/vault/init.sh
+++ b/vault/init.sh
@@ -45,12 +45,7 @@ then
     exit 1
 fi
 echo
-read -p "How many Vault replicas do you have? (kubectl get pods -n hashicorp-vault) " -r nb_replicas
-if [[ ! $nb_replicas =~ ^[0-9]+$ ]]
-then
-    echo 'This is not a number. Exiting.'
-    exit 1
-fi
+nb_replicas=$(kubectl get pods -n hashicorp-vault | grep -cE 'hashicorp-vault-[0-9]+')
 
 if [ -s "cluster-keys.json" ]
 then
@@ -80,7 +75,7 @@ do
     number=$(($i-2))
     echo "Unsealing pod ${j} with key ${number} out of ${key_nd} needed..."
     kubectl exec -n hashicorp-vault hashicorp-vault-$j -- vault operator unseal $key
-    sleep 1
+    sleep 2
   done
 done
 echo

--- a/vault/init.sh
+++ b/vault/init.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+printf "    __  __           __    _                     \n   / / / /___ ______/ /_  (_)________  _________ \n  / /_/ / __ \`/ ___/ __ \/ / ___/ __ \/ ___/ __ \\n / __  / /_/ (__  ) / / / / /__/ /_/ / /  / /_/ /\n/_/ /_/\__,_/____/_/ /_/_/\___/\____/_/  / .___/ \n _    _____   __  ____  ______          /_/     \n | |  / /   | / / / / / /_  __/                   \n| | / / /| |/ / / / /   / /                      \n| |/ / ___ / /_/ / /___/ /                       \n|___/_/  |_\____/_____/_/\n\n\n"
+printf "This script will allow you to initialize your Hashicorp Vault. In order to do so, the following requirements are needed:
+  * an uninitialized Hashicorp Vault
+  * the kubectl command line tool configured to access your Kubernetes cluster, on which the Vault is installed.
+
+If these requirements are met, the script will initialize the Vault and unseal it. The Vault's encryption algorithm is (by default) Shamir's algorithm. \e[1mn\e[0m keys (with n > 0) are generated, and \e[1mm\e[0m keys (with \e[1m0 < m <= n\e[0m) are needed to unseal the vault. The script will generate a cluster-keys.json file containing the keys and a root token to authenticate to the Vault. (which you may need for the next steps of the tutorial).
+
+If a cluster-keys.json file already exists, the script will use it to unseal the vault, and not generate any new keys.
+"
+read -p "Are the requirements all met? (y/Y) " -n 1 -r
+echo    # (optional) move to a new line
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo 'Requirements not met. Exiting.'
+    exit 1
+fi
+
+echo
+
+kubectl cluster-info
+
+echo 
+echo "This is the output of the command: kubectl cluster-info. "
+read -p "Do you confirm this is your cluster? (y/Y) " -n 1 -r
+echo    # (optional) move to a new line
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo 'Aborting.'
+    exit 1
+fi
+echo
+read -p "How many keys (n) do you want to generate? " -r key_nb
+if [[ ! $key_nb =~ ^[0-9]+$ ]]
+then
+    echo 'This is not a number. Exiting.'
+    exit 1
+fi
+echo
+read -p "How many keys (m) do you want to unseal the vault? " -r key_nd
+if [[ ! $key_nd =~ ^[0-9]+$ ]]
+then
+    echo 'This is not a number. Exiting.'
+    exit 1
+fi
+echo
+read -p "How many Vault replicas do you have? (kubectl get pods -n hashicorp-vault) " -r nb_replicas
+if [[ ! $nb_replicas =~ ^[0-9]+$ ]]
+then
+    echo 'This is not a number. Exiting.'
+    exit 1
+fi
+
+if [ -s "cluster-keys.json" ]
+then
+    echo "A cluster-keys.json file already exists and is not empty. "
+    read -p "Do you want to use it to unseal the vault? " -r -n 1
+    echo    # (optional) move to a new line
+    if [[ ! $REPLY =~ ^[Yy]$ ]]
+    then
+        echo 'Aborting.'
+        exit 1
+    fi
+    echo "Using existing keys..."
+else
+    echo "Generating the keys..."
+    kubectl exec -n hashicorp-vault hashicorp-vault-0 -- vault operator init \
+        -key-shares=$key_nb \
+        -key-threshold=$key_nd \
+        -format=json > cluster-keys.json
+fi
+
+# We get the m first keys to unseal the vault.
+for (( j=0 ; j<$nb_replicas ; j++ ))
+do
+  for (( i=3; i<=$((2+$key_nd)); i++ ))
+  do
+    key=$(sed "${i}q;d" cluster-keys.json | sed 's/ //g' | sed 's/\"//g' | sed 's/,//g')
+    number=$(($i-2))
+    echo "Unsealing pod ${j} with key ${number} out of ${key_nd} needed..."
+    kubectl exec -n hashicorp-vault hashicorp-vault-$j -- vault operator unseal $key
+  done
+done
+echo
+echo "Vault completely unsealed. You can now authenticate to the Vault with the root token in the cluster-keys.json file."
+exit 0

--- a/vault/init.sh
+++ b/vault/init.sh
@@ -80,6 +80,7 @@ do
     number=$(($i-2))
     echo "Unsealing pod ${j} with key ${number} out of ${key_nd} needed..."
     kubectl exec -n hashicorp-vault hashicorp-vault-$j -- vault operator unseal $key
+    sleep 1
   done
 done
 echo

--- a/vault/terraform.tf
+++ b/vault/terraform.tf
@@ -37,7 +37,6 @@ resource "vault_kubernetes_auth_backend_role" "vault_backend" {
   bound_service_account_namespaces = ["argocd"]
   token_ttl                        = 3600
   token_policies                   = ["argocd"]
-  audience                         = "vault"
 }
 
 resource "vault_policy" "vault_policy" {

--- a/vault/terraform.tf
+++ b/vault/terraform.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    vault = {
+      source = "hashicorp/vault"
+      version = "3.15.0"
+    }
+  }
+}
+
+provider "vault" {
+  address = var.vault_url
+  token   = var.vault_root_token
+}
+
+# Enable the kv secret engine to store key/value secrets
+resource "vault_mount" "kvv2" {
+  path        = "kv"
+  type        = "kv"
+  options     = { version = "2" }
+  description = "KV Version 2 secret engine mount"
+}
+
+resource "vault_kv_secret_backend_v2" "example" {
+  mount                = vault_mount.kvv2.path
+  max_versions         = 5
+  delete_version_after = 12600
+}

--- a/vault/terraform.tf
+++ b/vault/terraform.tf
@@ -25,3 +25,32 @@ resource "vault_kv_secret_backend_v2" "example" {
   max_versions         = 5
   delete_version_after = 12600
 }
+
+resource "vault_auth_backend" "kubernetes" {
+  type = "kubernetes"
+}
+
+resource "vault_kubernetes_auth_backend_role" "vault_backend" {
+  backend                          = vault_auth_backend.kubernetes.path
+  role_name                        = "argocd"
+  bound_service_account_names      = ["argocd-repo-server"]
+  bound_service_account_namespaces = ["argocd"]
+  token_ttl                        = 3600
+  token_policies                   = ["argocd"]
+  audience                         = "vault"
+}
+
+resource "vault_policy" "vault_policy" {
+  name = "argocd"
+
+  policy = <<EOT
+path "kv/*" {
+  capabilities = ["read"]
+}
+EOT
+}
+
+resource "vault_kubernetes_auth_backend_config" "vault_backend_config" {
+  backend                = vault_auth_backend.kubernetes.path
+  kubernetes_host        = var.kubernetes_api_url
+}

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -1,0 +1,10 @@
+variable "vault_root_token" {
+    type        = string
+    description = "The root token of the Vault server"
+    sensitive   = true
+}
+
+variable "vault_url" {
+    type        = string
+    description = "The URL of the Vault server"
+}

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -8,3 +8,8 @@ variable "vault_url" {
     type        = string
     description = "The URL of the Vault server"
 }
+
+variable "kubernetes_api_url" {
+    type        = string
+    description = "The URL of the Kubernetes API server (can be found in the kubeconfig file)"
+}


### PR DESCRIPTION
This PR adds some useful features for the Hashicorp Vault's

- enable the antiAffinity for the pods : by default, Hashicorp Vault will schedule 3 pods that will be spread on 3 nodes (if the node autoscaling feature is enabled on your cluster, then you will end with 3 nodes). This to ensure HA and avoid data loss in case of hardware failure.
- add some documentation for the README
- Build a new Terraform to do some initial configuration after the vault has been unsealed for the first time (enable the kv secret engine... to prepare ExternalSecrets & argocd-vault-plugin integration).