### PR TITLE
Add minssing depends argocd

### DIFF
--- a/common/argocd.tf
+++ b/common/argocd.tf
@@ -37,4 +37,8 @@ resource "helm_release" "argocd-apps" {
     )
   ]
 
+  depends_on = [
+    helm_release.argocd
+  ]
+
 }


### PR DESCRIPTION
Add required missing `depends_on` to install argocd-apps after the complete deployment of argocd.