### PR TITLE
Fix insecure Vault url

### DIFF
--- a/common/argocd-values.yaml.tftpl
+++ b/common/argocd-values.yaml.tftpl
@@ -209,7 +209,7 @@ extraObjects:
       name: vault-configuration
       namespace: argocd
     data:
-      VAULT_ADDR: ${vault_addr}
+      VAULT_ADDR: https://${vault_addr}
       AVP_TYPE: vault
       AVP_AUTH_TYPE: k8s
       AVP_K8S_ROLE: argocd


### PR DESCRIPTION
Add missing `https://` prefix to the Vault URL