### PR TITLE
Add dependencies to solve destruction order problem

### DIFF
--- a/ovh/ingress_controller.tf
+++ b/ovh/ingress_controller.tf
@@ -30,6 +30,10 @@ resource "helm_release" "ingress-nginx" {
     name  = "controller.extraArgs.enable-ssl-passthrough"
     value = "true"
   }
+
+  depends_on = [
+    ovh_cloud_project_kube_nodepool.pool
+  ]
 }
 
 resource "null_resource" "ingress-nginx" {

--- a/ovh/ingress_controller.tf
+++ b/ovh/ingress_controller.tf
@@ -31,9 +31,10 @@ resource "helm_release" "ingress-nginx" {
     value = "true"
   }
 
-  depends_on = [
-    ovh_cloud_project_kube_nodepool.pool
-  ]
+  set {
+    name  = "controller.admissionWebhooks.timeoutSeconds"
+    value = "30"
+  }
 }
 
 resource "null_resource" "ingress-nginx" {

--- a/scaleway/nginx-ingress.tf
+++ b/scaleway/nginx-ingress.tf
@@ -23,6 +23,9 @@ resource "helm_release" "ingress-nginx" {
     ip_adress = scaleway_lb_ip.nginx_ip.ip_address
   })]
 
+  depends_on = [
+    scaleway_k8s_pool.k8s_pool
+  ]
 }
 
 resource "null_resource" "ingress-nginx" {

--- a/scaleway/nginx-ingress.tf
+++ b/scaleway/nginx-ingress.tf
@@ -22,10 +22,6 @@ resource "helm_release" "ingress-nginx" {
     zone      = scaleway_lb_ip.nginx_ip.zone
     ip_adress = scaleway_lb_ip.nginx_ip.ip_address
   })]
-
-  depends_on = [
-    scaleway_k8s_pool.k8s_pool
-  ]
 }
 
 resource "null_resource" "ingress-nginx" {


### PR DESCRIPTION
This adds some depends_on in the Terraform so that a cluster can be safely destroyed (previously, node pools were destroyed before namespaces, resulting in the Terraform to crash and not deleting the cluster)