### PR TITLE
Rework CertManager installation

### DIFF
--- a/common/argocd.tf
+++ b/common/argocd.tf
@@ -11,7 +11,7 @@ resource "helm_release" "argocd" {
       {
         host_name           = var.argocd_hostname
         password            = var.argocd_password
-        cluster_issuer_name = var.cluster_issuer_name
+        cluster_issuer_name = var.main_cluster_issuer_name
         repo_url            = var.argocd_repo_url
         repo_username       = var.argocd_repo_username
         repo_password       = var.argocd_repo_password
@@ -20,7 +20,9 @@ resource "helm_release" "argocd" {
       }
     )
   ]
-
+  depends_on = [
+    helm_release.ingress-nginx
+  ]
 }
 
 resource "helm_release" "argocd-apps" {

--- a/common/cert-manager.tf
+++ b/common/cert-manager.tf
@@ -14,7 +14,7 @@ resource "helm_release" "cert_manager" {
 
 }
 
-resource "kubectl_manifest" "clusterissuer_letsencrypt_prod" {
+resource "kubectl_manifest" "clusterissuer" {
   for_each = { for issuer in var.issuers : issuer.name => issuer }
   provider = kubectl
   yaml_body = templatefile("issuer.yml.tftpl", {

--- a/common/cert-manager.tf
+++ b/common/cert-manager.tf
@@ -1,4 +1,5 @@
 module "cert_manager" {
+  count   = 0
   source  = "terraform-iaac/cert-manager/kubernetes"
   version = "2.5.0"
 
@@ -8,4 +9,35 @@ module "cert_manager" {
   cluster_issuer_server                  = var.cluster_issuer_server
   namespace_name                         = "cert-manager"
   create_namespace                       = true
+}
+
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  namespace        = "cert-manager"
+  create_namespace = true
+
+  repository = "https://charts.jetstack.io"
+  chart      = "cert-manager"
+  version    = "v1.11.1"
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+
+}
+
+resource "kubectl_manifest" "clusterissuer_letsencrypt_prod" {
+  for_each = { for issuer in var.issuers : issuer.name => issuer }
+  provider = kubectl
+  yaml_body = templatefile("issuer.yml.tftpl", {
+    name                    = each.value.name
+    email                   = each.value.email
+    server                  = each.value.server
+    private_key_secret_name = each.value.private_key_secret_name
+  })
+
+  depends_on = [
+    helm_release.cert_manager
+  ]
 }

--- a/common/cert-manager.tf
+++ b/common/cert-manager.tf
@@ -9,6 +9,10 @@ module "cert_manager" {
   cluster_issuer_server                  = var.cluster_issuer_server
   namespace_name                         = "cert-manager"
   create_namespace                       = true
+
+  depends_on = [
+    helm_release.ingress-nginx
+  ]
 }
 
 resource "helm_release" "cert_manager" {

--- a/common/cert-manager.tf
+++ b/common/cert-manager.tf
@@ -11,7 +11,7 @@ module "cert_manager" {
   create_namespace                       = true
 
   depends_on = [
-    helm_release.ingress-nginx
+    null_resource.ingress-nginx
   ]
 }
 

--- a/common/cert-manager.tf
+++ b/common/cert-manager.tf
@@ -4,7 +4,7 @@ module "cert_manager" {
   version = "2.5.0"
 
   cluster_issuer_email                   = var.letsencrypt_email
-  cluster_issuer_name                    = var.cluster_issuer_name
+  cluster_issuer_name                    = var.main_cluster_issuer_name
   cluster_issuer_private_key_secret_name = "cert-manager-private-key"
   cluster_issuer_server                  = var.cluster_issuer_server
   namespace_name                         = "cert-manager"

--- a/common/cert-manager.tf
+++ b/common/cert-manager.tf
@@ -1,20 +1,3 @@
-module "cert_manager" {
-  count   = 0
-  source  = "terraform-iaac/cert-manager/kubernetes"
-  version = "2.5.0"
-
-  cluster_issuer_email                   = var.letsencrypt_email
-  cluster_issuer_name                    = var.main_cluster_issuer_name
-  cluster_issuer_private_key_secret_name = "cert-manager-private-key"
-  cluster_issuer_server                  = var.cluster_issuer_server
-  namespace_name                         = "cert-manager"
-  create_namespace                       = true
-
-  depends_on = [
-    null_resource.ingress-nginx
-  ]
-}
-
 resource "helm_release" "cert_manager" {
   name             = "cert-manager"
   namespace        = "cert-manager"

--- a/common/hashicorp_vault.tf
+++ b/common/hashicorp_vault.tf
@@ -3,6 +3,10 @@ resource "kubernetes_namespace" "hashicorp-vault" {
   metadata {
     name = "hashicorp-vault"
   }
+
+  depends_on = [
+    helm_release.ingress-nginx
+  ]
 }
 
 resource "helm_release" "hashicorp-vault" {
@@ -28,4 +32,8 @@ resource "helm_release" "hashicorp-vault" {
     vault_server_hostname       = var.vault_server_hostname
     enable_vault_server_ingress = var.vault_server_hostname != "" ? true : false
   })]
+
+  depends_on = [
+    kubernetes_namespace.hashicorp-vault
+  ]
 }

--- a/common/hashicorp_vault.tf
+++ b/common/hashicorp_vault.tf
@@ -5,7 +5,7 @@ resource "kubernetes_namespace" "hashicorp-vault" {
   }
 
   depends_on = [
-    helm_release.ingress-nginx
+    null_resource.ingress-nginx
   ]
 }
 

--- a/common/hashicorp_vault.tf
+++ b/common/hashicorp_vault.tf
@@ -28,12 +28,13 @@ resource "helm_release" "hashicorp-vault" {
     vault_seal_method           = var.vault_seal_method
     vault_ui                    = var.vault_ui
 
-    cluster_issuer_name         = var.cluster_issuer_name
+    cluster_issuer_name         = var.main_cluster_issuer_name
     vault_server_hostname       = var.vault_server_hostname
     enable_vault_server_ingress = var.vault_server_hostname != "" ? true : false
   })]
 
   depends_on = [
-    kubernetes_namespace.hashicorp-vault
+    kubernetes_namespace.hashicorp-vault,
+    helm_release.ingress-nginx
   ]
 }

--- a/common/issuer.yml.tftpl
+++ b/common/issuer.yml.tftpl
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${name}
+spec:
+  acme:
+    email: ${email}
+    server: ${server}
+    privateKeySecretRef:
+      name: ${private_key_secret_name}
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/common/prometheus-grafana.tf
+++ b/common/prometheus-grafana.tf
@@ -8,8 +8,7 @@ resource "helm_release" "kube-prometheus" {
 
   values = [templatefile("${path.module}/prom-grafana-values.yml", {
     hostname               = var.grafana_hostname
-    issuer                 = var.cluster_issuer_name
+    issuer                 = var.main_cluster_issuer_name
     grafana_admin_password = var.grafana_admin_password
   })]
-
 }

--- a/common/tls-vault.tf
+++ b/common/tls-vault.tf
@@ -83,6 +83,10 @@ resource "kubernetes_secret" "tls" {
   }
 
   type = "kubernetes.io/tls"
+
+  depends_on = [
+    kubernetes_namespace.hashicorp-vault
+  ]
 }
 
 resource "kubernetes_secret" "tls_ca" {
@@ -94,4 +98,8 @@ resource "kubernetes_secret" "tls_ca" {
   data = {
     "ca.crt" = local.generate_tls_certs ? tls_self_signed_cert.ca[0].cert_pem : var.vault_api_ca_bundle
   }
+
+  depends_on = [
+    kubernetes_namespace.hashicorp-vault
+  ]
 }

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -45,6 +45,16 @@ variable "cluster_issuer_server" {
   description = "Server to use for the clusterIssuer"
 }
 
+variable "issuers" {
+  type = list(object({
+    name                    = string
+    email                   = string
+    server                  = string
+    private_key_secret_name = string
+  }))
+  description = "List of issuers to create"
+}
+
 variable "grafana_hostname" {
   type        = string
   description = "The hostname to use for the Grafana ingress"

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -1,9 +1,3 @@
-variable "main_cluster_issuer_name" {
-  type        = string
-  description = "Name of the clusterIssuer"
-  default     = "letsencrypt-prod"
-}
-
 variable "argocd_hostname" {
   type        = string
   description = "The hostname to use for the ArgoCD ingress"
@@ -45,6 +39,12 @@ variable "cluster_issuer_server" {
   description = "Server to use for the clusterIssuer"
 }
 
+variable "main_cluster_issuer_name" {
+  type        = string
+  description = "Name of the clusterIssuer"
+  default     = "letsencrypt-prod"
+}
+
 variable "issuers" {
   type = list(object({
     name                    = string
@@ -53,6 +53,19 @@ variable "issuers" {
     private_key_secret_name = string
   }))
   description = "List of issuers to create"
+  default = [
+    {
+      name                    = "letsencrypt-prod"
+      server                  = "https://acme-v02.api.letsencrypt.org/directory"
+      email                   = "admin@admin.fr",
+      private_key_secret_name = "letsencrypt-prod"
+      }, {
+      name                    = "letsencrypt-staging"
+      server                  = "https://acme-staging-v02.api.letsencrypt.org/directory"
+      email                   = "admin@admin.fr"
+      private_key_secret_name = "letsencrypt-staging"
+    }
+  ]
 }
 
 variable "grafana_hostname" {

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -1,7 +1,7 @@
-variable "cluster_issuer_name" {
+variable "main_cluster_issuer_name" {
   type        = string
   description = "Name of the clusterIssuer"
-  default     = "cert-manager-global"
+  default     = "letsencrypt-prod"
 }
 
 variable "argocd_hostname" {

--- a/ovh/.terraform.lock.hcl
+++ b/ovh/.terraform.lock.hcl
@@ -61,6 +61,25 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.1"
+  hashes = [
+    "h1:tSj1mL6OQ8ILGqR2mDu7OYYYWf+hoir0pf9KAQ8IzO8=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/time" {
   version = "0.9.1"
   hashes = [

--- a/ovh/ingress_controller.tf
+++ b/ovh/ingress_controller.tf
@@ -30,7 +30,9 @@ resource "helm_release" "ingress-nginx" {
     name  = "controller.extraArgs.enable-ssl-passthrough"
     value = "true"
   }
+}
 
+resource "null_resource" "ingress-nginx" {
   depends_on = [
     ovh_cloud_project_kube_nodepool.pool
   ]

--- a/ovh/ingress_controller.tf
+++ b/ovh/ingress_controller.tf
@@ -30,4 +30,8 @@ resource "helm_release" "ingress-nginx" {
     name  = "controller.extraArgs.enable-ssl-passthrough"
     value = "true"
   }
+
+  depends_on = [
+    ovh_cloud_project_kube_nodepool.pool
+  ]
 }

--- a/ovh/issuer.yml.tftpl
+++ b/ovh/issuer.yml.tftpl
@@ -1,0 +1,1 @@
+../common/issuer.yml.tftpl

--- a/scaleway/issuer.yml.tftpl
+++ b/scaleway/issuer.yml.tftpl
@@ -1,0 +1,1 @@
+../common/issuer.yml.tftpl

--- a/scaleway/nginx-ingress.tf
+++ b/scaleway/nginx-ingress.tf
@@ -23,6 +23,9 @@ resource "helm_release" "ingress-nginx" {
     ip_adress = scaleway_lb_ip.nginx_ip.ip_address
   })]
 
+}
+
+resource "null_resource" "ingress-nginx" {
   depends_on = [
     scaleway_k8s_pool.k8s_pool
   ]

--- a/scaleway/nginx-ingress.tf
+++ b/scaleway/nginx-ingress.tf
@@ -10,8 +10,8 @@ output "ingress_ip" {
   sensitive   = true
 }
 
-resource "helm_release" "nginx_ingress" {
-  name             = "nginx-ingress"
+resource "helm_release" "ingress-nginx" {
+  name             = "ingress-nginx"
   namespace        = "nginx"
   create_namespace = true
 
@@ -23,4 +23,7 @@ resource "helm_release" "nginx_ingress" {
     ip_adress = scaleway_lb_ip.nginx_ip.ip_address
   })]
 
+  depends_on = [
+    scaleway_k8s_pool.k8s_pool
+  ]
 }


### PR DESCRIPTION
Using helm chart instead of Terraform module + allow adding multiple issuers (for instance LetsEncrypt prod & staging)