### PR TITLE
Fix Vault dependency

### DIFF
--- a/common/argocd-values.yaml.tftpl
+++ b/common/argocd-values.yaml.tftpl
@@ -18,6 +18,7 @@ server:
           - ${host_name}
         secretName: argocd-secret # do not change, this is provided by Argo CD
 
+%{ if install_hashicorp_vault }
 repoServer:
   # Each of the embedded YAMLs inside argocd-cmp-cm ConfigMap will be mounted into it's respective plugin sidecar
   volumes:
@@ -120,6 +121,7 @@ repoServer:
         - name: custom-tools
           subPath: argocd-vault-plugin
           mountPath: /usr/local/bin/argocd-vault-plugin
+%{ endif }
 
 configs:
   secret:
@@ -131,6 +133,7 @@ configs:
       url: ${repo_url}
       username: ${repo_username}
       password: ${repo_password}
+%{ if install_hashicorp_vault }
   cmp:
     create: true
     plugins:
@@ -206,3 +209,4 @@ extraObjects:
       AVP_TYPE: vault
       AVP_AUTH_TYPE: k8s
       AVP_K8S_ROLE: argocd
+%{ endif }

--- a/common/argocd.tf
+++ b/common/argocd.tf
@@ -10,20 +10,23 @@ resource "helm_release" "argocd" {
   values = [
     templatefile("${path.module}/argocd-values.yaml.tftpl",
       {
-        host_name           = var.argocd_hostname
-        password            = var.argocd_password
-        cluster_issuer_name = var.main_cluster_issuer_name
-        repo_url            = var.argocd_repo_url
-        repo_username       = var.argocd_repo_username
-        repo_password       = var.argocd_repo_password
-        avp_version         = var.argocd_avp_version
-        vault_addr          = var.vault_server_hostname
+        host_name               = var.argocd_hostname
+        password                = var.argocd_password
+        cluster_issuer_name     = var.main_cluster_issuer_name
+        repo_url                = var.argocd_repo_url
+        repo_username           = var.argocd_repo_username
+        repo_password           = var.argocd_repo_password
+        avp_version             = var.argocd_avp_version
+        install_hashicorp_vault = var.install_hashicorp_vault
+        vault_addr              = var.vault_server_hostname
       }
     )
   ]
 }
 
 resource "helm_release" "argocd-apps" {
+  count = var.install_hashicorp_vault ? 1 : 0
+
   name = "argocd-apps"
 
   repository = "https://argoproj.github.io/argo-helm"


### PR DESCRIPTION
This MR disable the deployment of ArgoCD Vault plugin if the vault isn't installed. This avoid some misbehaviour in ArgoCD.