### PR TITLE
Allow to create apps without environment and suffix in name or namespace

### DIFF
--- a/common/argocd-apps-values.yaml.tftpl
+++ b/common/argocd-apps-values.yaml.tftpl
@@ -11,7 +11,7 @@ applicationsets:
     goTemplate: true
     template:
       metadata:
-        name: '{{ index .path.segments 1 }}-{{ index (splitList "." .path.filename) 0 }}'
+        name: '{{ index .path.segments 1 }}{{ if ne (index .path.segments 1) (index (splitList "." .path.filename) 0) }}-{{ index (splitList "." .path.filename) 0 }}{{ end }}'
       spec:
         project: default
         source:
@@ -27,7 +27,7 @@ applicationsets:
                 value: '{{ default "default-vault-credentials" .vaultCredentials }}'
         destination:
           server: https://kubernetes.default.svc
-          namespace: '{{ index .path.segments 1 }}-{{ index (splitList "." .path.filename) 0 }}'
+          namespace: '{{ index .path.segments 1 }}{{ if ne (index .path.segments 1) (index (splitList "." .path.filename) 0) }}-{{ index (splitList "." .path.filename) 0 }}{{ end }}'
         syncPolicy:
           automated:
             prune: true


### PR DESCRIPTION
Allow to create app without suffix in the name or the suffix, by using the app name as environment. Eg :

```
❯ tree apps
apps
├── argocd
│   ├── argocd.json
│   └── argocd.yaml
```

![image](https://github.com/openfun/kubic/assets/3728646/a82b2f86-1a34-48eb-ba80-576d4b8dc04f)

This PR can allow to create an argocd project and extend the argocd configuration using declarative configuration (official documentation : https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/) 


