### PR TITLE
♻️ (vault) remove secrets auto deletion

### DIFF
--- a/vault/terraform.tf
+++ b/vault/terraform.tf
@@ -23,7 +23,6 @@ resource "vault_mount" "kvv2" {
 resource "vault_kv_secret_backend_v2" "example" {
   mount                = vault_mount.kvv2.path
   max_versions         = 5
-  delete_version_after = 12600
 }
 
 resource "vault_auth_backend" "kubernetes" {


### PR DESCRIPTION
The secrets are automaticaly deleted after 3h30, therefore we cannot reuse them and must connect to the vault ui to re-enable them.

This should not be a default behavior ?