### PR TITLE
📦️ (velero) Add option to enable fs volume backup by default

### DIFF
--- a/common/variables.tf
+++ b/common/variables.tf
@@ -165,3 +165,8 @@ variable "velero_s3_secret_access_key" {
   sensitive   = true
 }
 
+variable "velero_default_volumes_to_fs_backup" {
+  type        = bool
+  description = "Enable volume filesystem backups by default"
+  default     = false
+}

--- a/common/velero-values.yml
+++ b/common/velero-values.yml
@@ -53,6 +53,7 @@ configuration:
   #    incremental:
   #    snapshotLocation:
   #    project:
+  defaultVolumesToFsBackup: ${velero_default_volumes_to_fs_backup}
 
 # Info about the secret to be used by the Velero deployment, which
 # should contain credentials for the cloud provider IAM account you've

--- a/common/velero.tf
+++ b/common/velero.tf
@@ -14,5 +14,6 @@ resource "helm_release" "velero" {
     velero_s3_bucket_endpoint   = var.velero_s3_bucket_endpoint
     velero_s3_access_key_id     = var.velero_s3_access_key_id
     velero_s3_secret_access_key = var.velero_s3_secret_access_key
+    velero_default_volumes_to_fs_backup = var.velero_default_volumes_to_fs_backup
   })]
 }

--- a/docs/velero.md
+++ b/docs/velero.md
@@ -11,6 +11,8 @@ When creating the cluster, all velero variables are to be set either manualy in 
 
 We use the opt-in approach from Velero to backup persistent volumes (more information [here](https://velero.io/docs/main/file-system-backup/)). This means that you need to add the following annotation to your pods, when you want its PVC to be saved : `backup.velero.io/backup-volumes: <volumes_names>, ...`. This will backup the persistent volume claim and the persistent volume associated with it.
 
+You can use the opt-out approach by setting `velero_default_volumes_to_fs_backup` to `true` in the `terraform.tfvars`.
+
 ## Velero's CLI
 
 Velero comes with a CLI to manage the backups. You can install it [here](https://velero.io/docs/v1.6/basic-install/). To bind the CLI to your cluster, just set the `--kubeconfig` flag when you run a command. Otherwise, Velero will use your default kubeconfig file.

--- a/ovh/terraform.tfvars.example
+++ b/ovh/terraform.tfvars.example
@@ -46,3 +46,4 @@ velero_s3_bucket_region     = "gra"
 velero_s3_bucket_endpoint   = "https://s3.gra.io.cloud.ovh.net"
 velero_s3_access_key_id     = "acb2c7815132b7157b881b83a002b3f"
 velero_s3_secret_access_key = "2d0f550387fa8a2073f3a8fc2062e28"
+velero_default_volumes_to_fs_backup = false

--- a/ovh/terraform.tfvars.template
+++ b/ovh/terraform.tfvars.template
@@ -40,3 +40,4 @@ velero_s3_bucket_region=""
 velero_s3_bucket_endpoint=""
 velero_s3_access_key_id=""
 velero_s3_secret_access_key=""
+velero_default_volumes_to_fs_backup=false

--- a/scaleway/terraform.tfvars.example
+++ b/scaleway/terraform.tfvars.example
@@ -43,3 +43,4 @@ velero_s3_bucket_region     = "gra"
 velero_s3_bucket_endpoint   = "https://s3.gra.io.cloud.ovh.net"
 velero_s3_access_key_id     = "acb2c7815132b7157b881b83a002b3f"
 velero_s3_secret_access_key = "2d0f550387fa8a2073f3a8fc2062e28"
+velero_default_volumes_to_fs_backup = false

--- a/scaleway/terraform.tfvars.template
+++ b/scaleway/terraform.tfvars.template
@@ -37,3 +37,4 @@ velero_s3_bucket_region     = ""
 velero_s3_bucket_endpoint   = ""
 velero_s3_access_key_id     = ""
 velero_s3_secret_access_key = ""
+velero_default_volumes_to_fs_backup =

--- a/standalone/terraform.tfvars.example
+++ b/standalone/terraform.tfvars.example
@@ -34,3 +34,4 @@ velero_s3_bucket_region     = "gra"
 velero_s3_bucket_endpoint   = "https://s3.gra.io.cloud.ovh.net"
 velero_s3_access_key_id     = "acb2c7815132b7157b881b83a002b3f"
 velero_s3_secret_access_key = "2d0f550387fa8a2073f3a8fc2062e28"
+velero_default_volumes_to_fs_backup = false

--- a/standalone/terraform.tfvars.template
+++ b/standalone/terraform.tfvars.template
@@ -28,3 +28,4 @@ velero_s3_bucket_region     = ""
 velero_s3_bucket_endpoint   = ""
 velero_s3_access_key_id     = ""
 velero_s3_secret_access_key = ""
+velero_default_volumes_to_fs_backup =


### PR DESCRIPTION
Persistants Volumes are backuped with an opt-in approach. This PR add an option to backup all volumes by default, do do not have to include them by labelling the pods (see https://velero.io/docs/v1.11/file-system-backup/).