### PR TITLE
🔧 (configuration) Variable argocd and vault helm charts versions

### DIFF
--- a/common/argocd.tf
+++ b/common/argocd.tf
@@ -6,6 +6,7 @@ resource "helm_release" "argocd" {
   repository = "https://argoproj.github.io/argo-helm"
   chart      = "argo-cd"
   timeout    = 600
+  version    = var.argocd_version
 
   values = [
     templatefile("${path.module}/argocd-values.yaml.tftpl",

--- a/common/hashicorp-vault.tf
+++ b/common/hashicorp-vault.tf
@@ -16,6 +16,7 @@ resource "helm_release" "hashicorp-vault" {
 
   repository = "https://helm.releases.hashicorp.com"
   chart      = "vault"
+  version    = var.vault_version
 
   values = [templatefile("${path.module}/vault-values.yml", {
     kubernetes_secret_name_tls_ca    = kubernetes_secret.tls_ca.metadata.0.name

--- a/common/variables.tf
+++ b/common/variables.tf
@@ -23,6 +23,12 @@ variable "argocd_repo_password" {
   description = "ArgoCD applications repo password"
 }
 
+variable "argocd_version" {
+  type        = string
+  description = "The version of ArgoCD helm release to install"
+  default     = "5.33.1"
+}
+
 variable "argocd_avp_version" {
   type        = string
   description = "ArgoCD argo-vault-plugin version"
@@ -129,6 +135,12 @@ variable "vault_seal_method" {
   type        = string
   description = "The Vault seal method to use"
   default     = "shamir"
+}
+
+variable "vault_version" {
+  type        = string
+  description = "The version of Hashicorp vault helm release to install"
+  default     = "1.24.12"
 }
 
 variable "velero_version" {


### PR DESCRIPTION
Add variable to configure ArgoCD and Hashicorp Vault Helm's charts versions.

This allow to pin version and protect from breaking changes bugs.