### PR TITLE
📝🙈 (standalone) Add Loki and format bullet points, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ terraform.rc
 
 # Hashicorp Vault keys file
 cluster-keys.json
+
+# standalone kubeconfig
+standalone/kubeconfig
+

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -3,11 +3,13 @@
 If you already have a cluster (with another provider or whatever), you can still use this Terraform to deploy all the mentioned tools on it, **if and only if you use ingress-nginx as your ingress controller**. For this, you will need a `kubeconfig` file to access your cluster. (or your credentials, if so, you will have to modify by yourself the `terraform.tf` file).
 
 This part will install :
+
 - Cert-manager, provisionned with issuers
 - Prometheus along Grafana
 - ArgoCD provisionned with a default repository
 - Velero
 - Hashicorp Vault
+- Loki
 
 ## Requirements
 
@@ -28,6 +30,7 @@ controller:
 ## Steps
 
 Follow the following steps (every command must be run at the root of the repository):
+
 - Run `bin/bootstrap.sh standalone` and fill the asked variables;
   - Only the most common variables are prompted, if you want to change other variables, you will have to edit the `standalone/terraform.tfvars` file by yourself. (the complete list of variables is available in the `standalone/variables.tf` file)
 - Run `bin/terraform-init.sh standalone` to initialize the Terraform state;


### PR DESCRIPTION
- Add `standalone/kubeconfig` to gitignore, as we must provide this file with a valid kubeconfig to use the standalone folder.
- Add loki on the standalone installed components list
- Format bullet-points to be markdown compatible