### PR TITLE
🐛 (Velero): Bump velero version to fix glibc error on crd upgrade

### DIFF
--- a/common/velero-values.yml
+++ b/common/velero-values.yml
@@ -6,7 +6,7 @@
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.11.0
+  tag: v1.13.0
 
 initContainers:
   - name: velero-plugin-for-aws


### PR DESCRIPTION
See https://github.com/vmware-tanzu/helm-charts/issues/559

An error occur when we install Kubic on a fresh cluster with versions before 1.13.

Upgrade from 1.11 to 1.13 not tested, I let it in draft